### PR TITLE
[Fix] Вместо ссылки на com-файл использован пакет Microsoft.Office.Interop.Excel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* 2025-04-08 #91 [Fix] Вместо ссылки на com-файл использован пакет Microsoft.Office.Interop.Excel от @aggink
 * 2025-04-08 #90 [Feature] Пример работы с xlsx-файлом используя установленный Microsoft Excel от @aggink
 * 2025-04-04 #83 [Feature] Реализовал интерфейс RationalNumber, покрыл тестами от @lsokol14l
 * 2025-04-04 #87 [Fix] Были изменены названия с task на Task от @kinkiss1

--- a/CoreLib.Utilities/CoreLib.Utilities.csproj
+++ b/CoreLib.Utilities/CoreLib.Utilities.csproj
@@ -3,15 +3,7 @@
   <Import Project="..\build.settings.props" />
 
   <ItemGroup>
-  	<COMReference Include="Microsoft.Office.Interop.Excel">
-  		<WrapperTool>tlbimp</WrapperTool>
-  		<VersionMinor>9</VersionMinor>
-  		<VersionMajor>1</VersionMajor>
-  		<Guid>{00020813-0000-0000-C000-000000000046}</Guid>
-  		<Lcid>0</Lcid>
-  		<Isolated>false</Isolated>
-  		<EmbedInteropTypes>true</EmbedInteropTypes>
-  	</COMReference>
+    <PackageReference Include="Microsoft.Office.Interop.Excel" Version="15.0.4795.1001" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
1️⃣ Введение

Ошибка сборки проекта через GitHub Action. Ругается на ссылку на com-файл, которая используется преимущественно в проектах NET Framework.

Преимущество использование com-файла в том, что он использует локальную версию Excel установленную на локальной машине. Библиотеке же нужна определенная версия Excel.

2️⃣ Краткое объяснение сути изменений

Вместо com-файла подключена библиотека Microsoft.Office.Interop.Excel

3️⃣ Как протестировано

Успешная локальная сборка проекта.