### PR TITLE
[FIX] Исправлены тесты с OperationCanceledException

### DIFF
--- a/Study.Lab2.Logic.UnitTests/chaspix/ServerRequestServiceTests.cs
+++ b/Study.Lab2.Logic.UnitTests/chaspix/ServerRequestServiceTests.cs
@@ -115,12 +115,12 @@ public class ServerRequestServiceTests
         using var cts = new CancellationTokenSource();
 
         _mockRequestService.Setup(x => x.FetchDataAsync(It.IsAny<string>(), null, cts.Token))
-            .ThrowsAsync(new OperationCanceledException(cts.Token));
+            .ThrowsAsync(new TaskCanceledException("The operation was canceled.", new OperationCanceledException(cts.Token)));
 
         cts.Cancel();
 
         // Act & Assert
-        Assert.ThrowsAsync<OperationCanceledException>(async () =>
+        Assert.ThrowsAsync<TaskCanceledException>(async () =>
             await _serverRequestService.GetCatFactAsync(cts.Token));
     }
 
@@ -134,12 +134,12 @@ public class ServerRequestServiceTests
 
         _mockRequestService.Setup(x => x.FetchDataAsync(
                 It.Is<string>(s => s.Contains($"q={city}")), null, cts.Token))
-            .ThrowsAsync(new OperationCanceledException(cts.Token));
+            .ThrowsAsync(new TaskCanceledException("The operation was canceled.", new OperationCanceledException(cts.Token)));
 
         cts.Cancel();
 
         // Act & Assert
-        Assert.ThrowsAsync<OperationCanceledException>(async () =>
+        Assert.ThrowsAsync<TaskCanceledException>(async () =>
             await _serverRequestService.GetWeatherInfoAsync(city, cts.Token));
     }
 }

--- a/Study.Lab2.Logic.UnitTests/kinkiss1/ServerRequestServiceTests.cs
+++ b/Study.Lab2.Logic.UnitTests/kinkiss1/ServerRequestServiceTests.cs
@@ -90,9 +90,9 @@ public class ServerRequestServiceTests
         _mockRequestService
             .Setup(s => s.FetchDataAsync(url, token))
             .Callback(() => cts.Cancel())
-            .ThrowsAsync(new OperationCanceledException(token));
+            .ThrowsAsync(new TaskCanceledException("The operation was canceled.", new OperationCanceledException(token)));
 
-        var exception = Assert.ThrowsAsync<OperationCanceledException>(async () =>
+        var exception = Assert.ThrowsAsync<TaskCanceledException>(async () =>
             await _serverRequestService.CatGetFactsAsync(token));
 
         Assert.That(exception.CancellationToken, Is.EqualTo(token));


### PR DESCRIPTION
- Заменены OperationCanceledException на TaskCanceledException в тестах отмены
- HttpClient в .NET выбрасывает TaskCanceledException, а не OperationCanceledException
- Исправлены тесты в chaspix и kinkiss1 ServerRequestServiceTests
- Это исправляет проваленный тест из коммита #307